### PR TITLE
Moving fluent-linter back to @main 

### DIFF
--- a/.github/workflows/fluent-linter.yml
+++ b/.github/workflows/fluent-linter.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -27,7 +26,7 @@ jobs:
         shell: bash
 
       - id: fluent_linter_action
-        uses: calyptia/fluent-linter-action@gg/problem-matcher-test
+        uses: calyptia/fluent-linter-action@main
         with:
           CALYPTIA_API_KEY: ${{ secrets.CALYPTIA_API_KEY }}
           CONFIG_LOCATION_GLOB: '/tmp/output.conf'

--- a/.github/workflows/fluent-linter.yml
+++ b/.github/workflows/fluent-linter.yml
@@ -1,0 +1,33 @@
+name: Config lint
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  config-lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - run: tools/flatten-config.sh > /tmp/output.conf
+        shell: bash
+
+      - id: fluent_linter_action
+        uses: calyptia/fluent-linter-action@main
+        with:
+          CALYPTIA_API_KEY: ${{ secrets.CALYPTIA_API_KEY }}
+          CONFIG_LOCATION_GLOB: '/tmp/output.conf'

--- a/.github/workflows/fluent-linter.yml
+++ b/.github/workflows/fluent-linter.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
 
       - id: fluent_linter_action
-        uses: calyptia/fluent-linter-action@main
+        uses: calyptia/fluent-linter-action@gg/problem-matcher-test
         with:
           CALYPTIA_API_KEY: ${{ secrets.CALYPTIA_API_KEY }}
           CONFIG_LOCATION_GLOB: '/tmp/output.conf'


### PR DESCRIPTION
After the tests, we can come back to `@main` 